### PR TITLE
add formatting decimals with sup depending on appSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.1.5] - 2020-11-09
+### Added
+- Settings to add sup tag on decimals.
+
 ## [0.1.4] - 2020-06-09
 ### Fixed
 - Romanian currency format.

--- a/manifest.json
+++ b/manifest.json
@@ -14,5 +14,18 @@
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },
+  "settingsSchema": {
+    "title": "Format Currency",
+    "type": "object",
+    "properties": {
+      "currencyWithSupFormatting": {
+        "title": "Format currency with sup formatting",
+        "type": "boolean",
+        "default": false,
+        "access": "public",
+        "description": "Currency will be formatted making the decimals sup"
+      }
+    }
+  },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/FormattedCurrency.tsx
+++ b/react/FormattedCurrency.tsx
@@ -3,19 +3,17 @@ import { useRuntime } from 'vtex.render-runtime'
 import { useIntl } from 'react-intl'
 import formatCurrency from './formatCurrency'
 
-const FormattedCurrency: FC<FormattedCurrencyProps> = ({
-  value,
-}) => {
-  const { culture } = useRuntime()
+const FormattedCurrency: FC<FormattedCurrencyProps> = ({ value }) => {
+  const { culture, getSettings } = useRuntime()
+  const appSettings: {
+    currencyWithSupFormatting: boolean
+  } = getSettings('vtex.format-currency')
+
   const intl = useIntl()
 
-  const number = formatCurrency({ intl, culture, value })
+  const number = formatCurrency({ intl, culture, value, appSettings })
 
-  return (
-    <Fragment>
-      {number}
-    </Fragment>
-  )
+  return <Fragment>{number}</Fragment>
 }
 
 interface FormattedCurrencyProps {

--- a/react/formatCurrency.ts
+++ b/react/formatCurrency.ts
@@ -1,4 +1,5 @@
 import { IntlShape, FormatNumberOptions } from 'react-intl'
+import withFormattedDecimals from './withFormattedDecimals'
 
 interface FormatCurrencyParams {
   intl: IntlShape
@@ -8,12 +9,16 @@ interface FormatCurrencyParams {
     customCurrencyDecimalDigits?: number | null
     customCurrencySymbol?: string | null
   }
+  appSettings?: {
+    currencyWithSupFormatting: boolean
+  }
 }
 
 export default function formatCurrency({
   intl,
   culture,
   value,
+  appSettings,
 }: FormatCurrencyParams) {
   const formatOptions: FormatNumberOptions = {
     style: 'currency',
@@ -27,11 +32,20 @@ export default function formatCurrency({
   /**
    * The default Romanian currency format is wrong
    * https://stackoverflow.com/questions/57526989/return-correct-currency-for-intl-numberformat-romanian-lei
-  */
+   */
+  let formattedValue = undefined
+
   if (culture.currency === 'RON' && intl.locale.indexOf('ro') === 0) {
     formatOptions.currencyDisplay = 'name'
-    return intl.formatNumber(value, formatOptions).replace(' românești', '')
+
+    formattedValue = intl
+      .formatNumber(value, formatOptions)
+      .replace(' românești', '')
+  } else {
+    formattedValue = intl.formatNumber(value, formatOptions)
   }
 
-  return intl.formatNumber(value, formatOptions)
+  return appSettings?.currencyWithSupFormatting
+    ? withFormattedDecimals({ formattedValue })
+    : formattedValue
 }

--- a/react/withFormattedDecimals.tsx
+++ b/react/withFormattedDecimals.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+const withFormattedDecimals = ({
+  formattedValue,
+}: {
+  formattedValue: string | undefined | null
+}) => {
+  if (!formattedValue) {
+    return null
+  }
+  const regex = /(,)(\d*)/g
+  const groups = regex.exec(formattedValue)
+
+  const arrayElements = formattedValue.split(/,\d*/)
+  return (
+    <>
+      {arrayElements.map((value: string, index: number) => {
+        return (
+          <>
+            {value}
+            {index !== arrayElements.length - 1 && (
+              <WithFormattedDecimals groups={groups} />
+            )}
+          </>
+        )
+      })}
+    </>
+  )
+}
+
+const WithFormattedDecimals = (props: { groups: string[] | null }) => {
+  const { groups } = props
+  return groups && groups[1] && groups[2] ? (
+    <>
+      {groups[1]}
+      <sup>{groups[2]}</sup>
+    </>
+  ) : (
+    <></>
+  )
+}
+
+export default withFormattedDecimals


### PR DESCRIPTION
#### What problem is this solving?

There was a need of a client to show the decimals with "sup" tag.

#### How should this be manually tested?

[Workspace](https://currencywithsup--vtexromania.myvtex.com/)

#### Checklist/Reminders

- [X] Updated `CHANGELOG.md`.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/68271795/92941293-dc630e00-f458-11ea-9ce5-78d1f00bfcca.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
V | New feature <!-- a non-breaking change which adds functionality -->

#### Notes

In the workspace it is linked the code with the not condition because It cannot access the appSettings unless de app is deployed
