### PR TITLE
Fix thousand separator for "es" locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix for the "es" thousand comma separator issue.
 
 ## [0.3.0] - 2020-12-17
 ### Changed

--- a/react/FormattedCurrency.tsx
+++ b/react/FormattedCurrency.tsx
@@ -62,6 +62,19 @@ function FormattedCurrency({ value, classes }: Props) {
     return <span className={handles.currencyContainer}>{number}</span>
   }
 
+  /**
+ * The default "es" currency format is not following the normal conventions of comma separators
+ * The comma separator should be each 3 integers ($1,876.00)
+ * This validation ensures that the issue on "es" currency locale by UNICODE has a workarround
+ * https://unicode-org.atlassian.net/browse/CLDR-13762
+ * https://unicode-org.atlassian.net/projects/CLDR/issues/CLDR-13265?filter=allissues&orderby=created%20DESC&keyword=spanish
+ */
+  if (culture.language == 'es') {
+    const number = formatCurrency({ intl, culture, value })
+
+    return <span className={handles.currencyContainer}>{number}</span>
+  }
+
   const formatOptions: FormatNumberOptions = {
     style: 'currency',
     currency: culture.currency,

--- a/react/FormattedCurrency.tsx
+++ b/react/FormattedCurrency.tsx
@@ -5,6 +5,7 @@ import { useCssHandles } from 'vtex.css-handles'
 import type { CssHandlesTypes } from 'vtex.css-handles'
 
 import formatCurrency from './formatCurrency'
+import CustomFormat from './typings/CustomFormat'
 
 const formatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
@@ -48,28 +49,29 @@ const handlesMap: Record<Intl.NumberFormatPartTypes, string> = {
 interface Props {
   value: number
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+  customFormat?: CustomFormat
 }
 
-function FormattedCurrency({ value, classes }: Props) {
+function FormattedCurrency({ value, classes, customFormat }: Props) {
   const { culture } = useRuntime()
   const intl = useIntl()
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
 
-  // In case it's IE11
-  if (!hasFormatToParts) {
-    const number = formatCurrency({ intl, culture, value })
+  /**
+* The default "es" currency format is not following the normal conventions of comma separators
+* The comma separator should be each 3 integers ($1,876.00)
+* This validation ensures that the issue on "es" currency locale by UNICODE has a workarround
+* https://unicode-org.atlassian.net/browse/CLDR-13762
+* https://unicode-org.atlassian.net/projects/CLDR/issues/CLDR-13265?filter=allissues&orderby=created%20DESC&keyword=spanish
+*/
+  if (culture.language == 'es' || customFormat) {
+    const number = formatCurrency({ intl, culture, value, customFormat })
 
     return <span className={handles.currencyContainer}>{number}</span>
   }
 
-  /**
- * The default "es" currency format is not following the normal conventions of comma separators
- * The comma separator should be each 3 integers ($1,876.00)
- * This validation ensures that the issue on "es" currency locale by UNICODE has a workarround
- * https://unicode-org.atlassian.net/browse/CLDR-13762
- * https://unicode-org.atlassian.net/projects/CLDR/issues/CLDR-13265?filter=allissues&orderby=created%20DESC&keyword=spanish
- */
-  if (culture.language == 'es') {
+  // In case it's IE11
+  if (!hasFormatToParts) {
     const number = formatCurrency({ intl, culture, value })
 
     return <span className={handles.currencyContainer}>{number}</span>

--- a/react/formatCurrency.ts
+++ b/react/formatCurrency.ts
@@ -1,4 +1,5 @@
 import { IntlShape, FormatNumberOptions } from 'react-intl'
+import CustomFormat from './typings/CustomFormat'
 import Format from './utils'
 
 interface FormatCurrencyParams {
@@ -10,12 +11,14 @@ interface FormatCurrencyParams {
     customCurrencySymbol?: string | null
     language: string | null
   }
+  customFormat?: CustomFormat
 }
 
 export default function formatCurrency({
   intl,
   culture,
   value,
+  customFormat
 }: FormatCurrencyParams) {
   const formatOptions: FormatNumberOptions = {
     style: 'currency',
@@ -33,17 +36,20 @@ export default function formatCurrency({
    * https://unicode-org.atlassian.net/browse/CLDR-13762
    * https://unicode-org.atlassian.net/projects/CLDR/issues/CLDR-13265?filter=allissues&orderby=created%20DESC&keyword=spanish
    */
-  if (culture.language == 'es') {
-    let props = {
-      prefix: culture.customCurrencySymbol ?? undefined,
-      decimalScale: culture.customCurrencyDecimalDigits ?? undefined
+  if (culture.language == 'es' || customFormat) {
+
+    const newFormat = {
+      ...customFormat,
+      prefix: customFormat?.prefix ? customFormat?.prefix : culture.customCurrencySymbol,
+      decimalScale: customFormat?.decimalScale ? customFormat?.decimalScale : culture.customCurrencyDecimalDigits
     }
 
-    if (!props.prefix) delete props.prefix
-    if (!props.decimalScale) delete props.decimalScale
+    if (!newFormat.prefix) delete newFormat.prefix
+    if (!newFormat.decimalScale) delete newFormat.decimalScale
 
-    return new Format(props).currency(`${value}`)
+    return new Format(newFormat).currency(`${value}`)
   }
+
 
   /**
    * The default Romanian currency format is wrong

--- a/react/formatCurrency.ts
+++ b/react/formatCurrency.ts
@@ -1,4 +1,5 @@
 import { IntlShape, FormatNumberOptions } from 'react-intl'
+import Format from './utils'
 
 interface FormatCurrencyParams {
   intl: IntlShape
@@ -7,6 +8,7 @@ interface FormatCurrencyParams {
     currency: string
     customCurrencyDecimalDigits?: number | null
     customCurrencySymbol?: string | null
+    language: string | null
   }
 }
 
@@ -22,6 +24,25 @@ export default function formatCurrency({
 
   if (culture.customCurrencyDecimalDigits != null) {
     formatOptions.minimumFractionDigits = culture.customCurrencyDecimalDigits
+  }
+
+  /**
+   * The default "es" currency format is not following the normal conventions of comma separators
+   * The comma separator should be each 3 integers ($1,876.00)
+   * This validation ensures that the issue on "es" currency locale by UNICODE has a workarround
+   * https://unicode-org.atlassian.net/browse/CLDR-13762
+   * https://unicode-org.atlassian.net/projects/CLDR/issues/CLDR-13265?filter=allissues&orderby=created%20DESC&keyword=spanish
+   */
+  if (culture.language == 'es') {
+    let props = {
+      prefix: culture.customCurrencySymbol ?? undefined,
+      decimalScale: culture.customCurrencyDecimalDigits ?? undefined
+    }
+
+    if (!props.prefix) delete props.prefix
+    if (!props.decimalScale) delete props.decimalScale
+
+    return new Format(props).currency(`${value}`)
   }
 
   /**

--- a/react/formatCurrency.ts
+++ b/react/formatCurrency.ts
@@ -37,15 +37,20 @@ export default function formatCurrency({
    * https://unicode-org.atlassian.net/projects/CLDR/issues/CLDR-13265?filter=allissues&orderby=created%20DESC&keyword=spanish
    */
   if (culture.language == 'es' || customFormat) {
-
-    const newFormat = {
-      ...customFormat,
-      prefix: customFormat?.prefix ? customFormat?.prefix : culture.customCurrencySymbol,
-      decimalScale: customFormat?.decimalScale ? customFormat?.decimalScale : culture.customCurrencyDecimalDigits
+    const newFormat: CustomFormat = {
+      ...customFormat
     }
 
-    if (!newFormat.prefix) delete newFormat.prefix
-    if (!newFormat.decimalScale) delete newFormat.decimalScale
+    // Get parts from intl defaults
+    const parts = intl.formatNumberToParts(value * 10000, formatOptions)
+    const decimal = [...parts.filter(({ type }) => type == 'decimal')].shift()?.value
+    const group = [...parts.filter(({ type }) => type == 'group')].shift()?.value
+
+    // Set Enviroment defaults
+    if (!customFormat?.decimalSeparator && decimal) newFormat.decimalSeparator = decimal
+    if (!customFormat?.thousandSeparator && decimal) newFormat.thousandSeparator = group
+    if (!customFormat?.prefix) newFormat.prefix = culture.customCurrencySymbol
+    if (!customFormat?.decimalScale) newFormat.decimalScale = culture.customCurrencyDecimalDigits
 
     return new Format(newFormat).currency(`${value}`)
   }

--- a/react/typings/CustomFormat.d.ts
+++ b/react/typings/CustomFormat.d.ts
@@ -1,0 +1,16 @@
+export default interface CustomFormat {
+    decimalSeparator?: string
+    thousandsGroupStyle?: string
+    fixedDecimalScale?: boolean
+    prefix?: string | null
+    suffix?: string
+    allowNegative?: boolean
+    allowEmptyFormatting?: boolean
+    allowLeadingZeros?: boolean
+    isNumericString?: boolean
+    type?: string
+    decimalScale?: number | null
+    format?: string
+    thousandSeparator?: boolean | string
+    allowedDecimalSeparators?: [string?, string?]
+}

--- a/react/utils.ts
+++ b/react/utils.ts
@@ -1,0 +1,139 @@
+type PropsType = {
+    decimalSeparator?: string
+    thousandsGroupStyle?: string
+    fixedDecimalScale?: boolean
+    prefix?: string
+    suffix?: string
+    allowNegative?: boolean
+    allowEmptyFormatting?: boolean
+    allowLeadingZeros?: boolean
+    isNumericString?: boolean
+    type?: string
+    decimalScale?: number
+    format?: string
+    thousandSeparator?: boolean | string
+    allowedDecimalSeparators?: [string?, string?]
+}
+
+const defaultProps: PropsType = {
+    decimalSeparator: '.',
+    thousandsGroupStyle: 'thousand',
+    fixedDecimalScale: true,
+    prefix: '$',
+    suffix: '',
+    allowNegative: true,
+    allowEmptyFormatting: true,
+    allowLeadingZeros: false,
+    isNumericString: true,
+    type: 'text',
+    decimalScale: 2,
+    format: '',
+    thousandSeparator: true,
+    allowedDecimalSeparators: ['', ',']
+};
+
+export default class Format {
+    props: PropsType;
+    constructor(props: PropsType = defaultProps) {
+        this.props = props ? { ...defaultProps, ...props } : defaultProps
+    }
+
+    public currency = (value: string) => {
+        console.log(this.props);
+        
+        const { thousandSeparator, decimalSeparator } = this.getSeparators();
+
+        const hasDecimalSeparator = value.indexOf('.') !== -1 || (this.props.decimalScale && this.props.fixedDecimalScale);
+        let { beforeDecimal, afterDecimal, addNegation } = this.splitDecimal(value, this.props.allowNegative);
+
+        //apply decimal precision if its defined
+        if (this.props.decimalScale !== undefined) {
+            afterDecimal = this.limitToScale(afterDecimal, this.props.decimalScale, this.props.fixedDecimalScale);
+        }
+
+        if (thousandSeparator) {
+            beforeDecimal = this.applyThousandSeparator(beforeDecimal, thousandSeparator, this.props.thousandsGroupStyle);
+        }
+
+        //add prefix and suffix
+        if (this.props.prefix) beforeDecimal = this.props.prefix + beforeDecimal;
+        if (this.props.suffix) afterDecimal = afterDecimal + this.props.suffix;
+
+        //restore negation sign
+        if (addNegation) beforeDecimal = '-' + beforeDecimal;
+
+        value = beforeDecimal + ((hasDecimalSeparator && decimalSeparator) || '') + afterDecimal;
+
+        return value;
+    }
+
+    private getSeparators = () => {
+        const { decimalSeparator } = this.props;
+        let { thousandSeparator, allowedDecimalSeparators } = this.props;
+
+        if (thousandSeparator === true) {
+            thousandSeparator = ',';
+        }
+        if (!allowedDecimalSeparators) {
+            allowedDecimalSeparators = [decimalSeparator, '.'];
+        }
+
+        return {
+            decimalSeparator,
+            thousandSeparator,
+            allowedDecimalSeparators,
+        };
+    }
+
+    private splitDecimal = (numStr: string, allowNegative: boolean = true) => {
+        const hasNagation = numStr[0] === '-';
+        const addNegation = hasNagation && allowNegative;
+        numStr = numStr.replace('-', '');
+
+        const parts = numStr.split('.');
+        const beforeDecimal = parts[0];
+        const afterDecimal = parts[1] || '';
+
+        return {
+            beforeDecimal,
+            afterDecimal,
+            hasNagation,
+            addNegation,
+        };
+    }
+
+    private limitToScale = (numStr: string, scale: number, fixedDecimalScale?: boolean) => {
+        let str = '';
+        const filler = fixedDecimalScale ? '0' : '';
+        for (let i = 0; i <= scale - 1; i++) {
+            str += numStr[i] || filler;
+        }
+        return str;
+    }
+
+    private applyThousandSeparator = (
+        str: string,
+        thousandSeparator: string,
+        thousandsGroupStyle?: string,
+    ) => {
+        const thousandsGroupRegex = this.getThousandsGroupRegex(thousandsGroupStyle);
+        let index = str.search(/[1-9]/);
+        index = index === -1 ? str.length : index;
+        return (
+            str.substring(0, index) +
+            str.substring(index, str.length).replace(thousandsGroupRegex, '$1' + thousandSeparator)
+        );
+    }
+
+    private getThousandsGroupRegex = (thousandsGroupStyle?: string) => {
+        switch (thousandsGroupStyle) {
+            case 'lakh':
+                return /(\d+?)(?=(\d\d)+(\d)(?!\d))(\.\d+)?/g;
+            case 'wan':
+                return /(\d)(?=(\d{4})+(?!\d))/g;
+            case 'thousand':
+            default:
+                return /(\d)(?=(\d{3})+(?!\d))/g;
+        }
+    }
+}

--- a/react/utils.ts
+++ b/react/utils.ts
@@ -1,21 +1,6 @@
-type PropsType = {
-    decimalSeparator?: string
-    thousandsGroupStyle?: string
-    fixedDecimalScale?: boolean
-    prefix?: string
-    suffix?: string
-    allowNegative?: boolean
-    allowEmptyFormatting?: boolean
-    allowLeadingZeros?: boolean
-    isNumericString?: boolean
-    type?: string
-    decimalScale?: number
-    format?: string
-    thousandSeparator?: boolean | string
-    allowedDecimalSeparators?: [string?, string?]
-}
+import CustomFormat from "./typings/CustomFormat";
 
-const defaultProps: PropsType = {
+const defaultProps: CustomFormat = {
     decimalSeparator: '.',
     thousandsGroupStyle: 'thousand',
     fixedDecimalScale: true,
@@ -33,9 +18,9 @@ const defaultProps: PropsType = {
 };
 
 export default class Format {
-    props: PropsType;
-    constructor(props: PropsType = defaultProps) {
-        this.props = props ? { ...defaultProps, ...props } : defaultProps
+    props: CustomFormat;
+    constructor(props: CustomFormat = defaultProps) {
+        this.props = { ...defaultProps, ...props }
     }
 
     public currency = (value: string) => {
@@ -46,7 +31,7 @@ export default class Format {
 
         //apply decimal precision if its defined
         if (this.props.decimalScale !== undefined) {
-            afterDecimal = this.limitToScale(afterDecimal, this.props.decimalScale, this.props.fixedDecimalScale);
+            afterDecimal = this.limitToScale(afterDecimal, this.props.decimalScale ?? 2, this.props.fixedDecimalScale);
         }
 
         if (thousandSeparator) {

--- a/react/utils.ts
+++ b/react/utils.ts
@@ -39,8 +39,6 @@ export default class Format {
     }
 
     public currency = (value: string) => {
-        console.log(this.props);
-        
         const { thousandSeparator, decimalSeparator } = this.getSeparators();
 
         const hasDecimalSeparator = value.indexOf('.') !== -1 || (this.props.decimalScale && this.props.fixedDecimalScale);


### PR DESCRIPTION
#### What problem is this solving?

   The default "es" currency format is not following the normal conventions of comma separators for thousands
   The comma separator should be each 3 integers like ($1,876.00)
   This validation ensures that the issue on "es" currency locale by UNICODE has a workaround
   * https://unicode-org.atlassian.net/browse/CLDR-13762
   * https://unicode-org.atlassian.net/projects/CLDR/issues/CLDR-13265?filter=allissues&orderby=created%20DESC&keyword=spanish
   

#### How should this be manually tested?
Just adding items to the cart until the total is >= $1,000.00
[Workspace](https://commafix--tiendamx.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshot without the fix
<img width="1680" alt="Screen Shot 2021-02-03 at 8 41 36" src="https://user-images.githubusercontent.com/65255533/106762869-e3eba500-65fb-11eb-8574-29feffd66596.png">

#### Screenshot with the fix
<img width="1680" alt="Screen Shot 2021-02-03 at 8 40 36" src="https://user-images.githubusercontent.com/65255533/106762888-e8b05900-65fb-11eb-904a-4ff927d07502.png">

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
