### PR TITLE
feat: read custom currency from Trade Policy when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Custom Currency Symbol from Trade Policy into `FormattedCurrency` when available.
 
 ## [0.3.0] - 2020-12-17
 ### Changed

--- a/react/FormattedCurrency.tsx
+++ b/react/FormattedCurrency.tsx
@@ -51,7 +51,8 @@ interface Props {
 }
 
 function FormattedCurrency({ value, classes }: Props) {
-  const { culture } = useRuntime()
+  const { culture, getSettings } = useRuntime()
+  const settings = getSettings('vtex.store')
   const intl = useIntl()
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
 
@@ -97,6 +98,16 @@ function FormattedCurrency({ value, classes }: Props) {
             lei
           </span>
         )
+      }
+
+      if (part.type === 'currency' && 
+      culture?.customCurrencySymbol.length > 0 &&
+      settings?.enableCustomCurrencySymbol) {
+        return (
+            <span key={index} className={handle}>
+              {culture.customCurrencySymbol}
+            </span>
+          )
       }
 
       return (

--- a/react/FormattedCurrency.tsx
+++ b/react/FormattedCurrency.tsx
@@ -100,15 +100,17 @@ function FormattedCurrency({ value, classes }: Props) {
         )
       }
 
-      if (part.type === 'currency' && 
+    if (
+      part.type === 'currency' &&
       culture?.customCurrencySymbol.length > 0 &&
-      settings?.enableCustomCurrencySymbol) {
-        return (
-            <span key={index} className={handle}>
-              {culture.customCurrencySymbol}
-            </span>
-          )
-      }
+      settings?.enableCustomCurrencySymbol
+    ) {
+      return (
+        <span key={index} className={handle}>
+          {culture.customCurrencySymbol}
+        </span>
+      )
+    }
 
       return (
         <span key={index} className={handle}>


### PR DESCRIPTION
#### What problem is this solving?

Currently, the user is not able to get the value from the custom currency symbol in Trade Policy, this feature allows the user to retrieve it

#### How to test it?

Account: koestore
Product id: 1

First of all, you need to define your custom currency symbol at the trade policy screen:

`admin/Site/StoreForm.aspx?Id=1`

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/13649073/178053085-24296d79-78c8-41af-921b-da61f1a9b65e.png">

Set the flag `enableCustomCurrencySymbol` as true in your store search settings doing a PUT to the request:

```
curl --request GET \
  --url https://infra.io.vtex.com/apps/v0/koestore/iespinoza2/apps/vtex.store/settings \
  --header 'VtexIdclientAutCookie: xxx'
```

Adding the following:

`"enableCustomCurrencySymbol": true`


Check the product page or any other page that has the currency symbol:

[PDP with the fix:](https://iespinoza2--koestore.myvtex.com/camisa-botafogo/p) 

<img width="1265" alt="image" src="https://user-images.githubusercontent.com/13649073/178053782-512c4e98-2380-429f-8a4b-33d668601d5f.png">

[PDP without the fix getting from intl:](https://master--koestore.myvtex.com/camisa-botafogo/p) 

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/13649073/178054084-44a613f2-dd6c-4da5-a2af-918c2f9cb054.png">


#### Describe alternatives you've considered if any.

I'm going to add another PR's adding the process of a PUT in the store.settings UI instead of doing it through API, but maybe, we should consider getting the custom currency as default (?)


#### Related to / Depends on

This PR add the enableCustomCurrency in store settings screen: https://github.com/vtex-apps/store/pull/556

This other PR add the translations for enableCustomCurrency: https://github.com/vtex-apps/admin-pages/pull/430

Zendesk 590112

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/3o8doUeyrZAinxcGBi/giphy.gif)
