### PR TITLE
fix: some admin apps dont use customcurrency in culture info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+- Some admin apps don't use custom currency symbol, refactoring logic
 
 ## [0.4.0] - 2022-07-11
 ### Added

--- a/react/FormattedCurrency.tsx
+++ b/react/FormattedCurrency.tsx
@@ -102,7 +102,7 @@ function FormattedCurrency({ value, classes }: Props) {
 
     if (
       part.type === 'currency' &&
-      culture?.customCurrencySymbol.length > 0 &&
+      culture?.customCurrencySymbol &&
       settings?.enableCustomCurrencySymbol
     ) {
       return (


### PR DESCRIPTION
#### What problem is this solving?

Some apps don't use culture info, refactoring the code because it breaked some apps

#### How should this be manually tested?

[Workspace](https://fila--powerplanet.myvtex.com/admin/returns/9a8abdce-0129-11ed-835d-0ab01054b875/details/)

<img width="1240" alt="image" src="https://user-images.githubusercontent.com/13649073/178350594-791e6231-d197-4d5d-9b75-ba78d3769cda.png">

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
